### PR TITLE
Modifications to Selectors adding msqc as prefix for contentful entri…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,24 @@
-# Contetnful Sidekick
-Chrome Extension that helps end users of Contentful find the content they want to edit quickly on highly nested pages that use alot of different peices of content to make up the page.
+# MSQC Contetnful Sidekick
+Is a fork of the Contentful Sidekick Chrome Extension that helps end users of Contentful find the content they want to edit quickly on highly nested pages that use alot of different peices of content to make up the page. It is customized to work with MSQC's specific Contentful configuration and structure. If you are looking at forking this you might have better luck with the origional.
 
 ## Download
 You can download the released version on the [Chrome Web Store](https://chrome.google.com/webstore/detail/contentful-sidekick/cmheemjjmooepppggclooeejginffobo).<br>
 **IMPORTANT: before you use the sidekick you must first enable it by adding html attributes to your page**
 
 ## Enabling for your site
-The Contentful Sidekick uses a data attribute on the element you want to enable editing for. Typically this is placed on an elment that corrisponds to a different content model.
+The Contentful Sidekick uses Two data attributes on the elements you want to enable editing for. Typically this is placed on an elment that corrisponds to a different content model. Because MSQC mixes Spaces we need to add the Space ID to each content model to enable building the correct link for each entry.
 
-### Add this to your top meta tags
-```html
-<meta name="contentful_space" content="<space-id>">
-<meta name="contentful_environment" content="<environment>">
-```
 ### Add this to your HTML element
-**Tip**: A good practice is to only add these tags on a staging or preview environment
+**Tip**: A good practice is to only add these tags on a staging or preview environment... But... We are going to skip leveraging the environment variable since we currently don't utilize it.
 ```
-data-csk-entry-id="${entry.sys.id}"
+<div class="contentful-module full-text" data-msqc-entry-id="{{$entryId}}" data-msqc-space-id="{{$entryId}}">
 ```
-Example:
+Example of a Blade partial for a specific Content Model:
 
 ```html
-<div class="module-panel" data-csk-entry-id="js7sjsushs63h36shsgd63g">
-  <div class="panel-hsc" data-csk-entry-id="jsshs7j2y2hhgsysjjdkkfie">
-    ...
-  </div>
-
-  <div class="panel-hsc" data-csk-entry-id="aksisuw7whsywhsywi28282">
-    ...
-    <div class="another-content-model" data-csk-entry-id="pow982kj282mm2hjsd72nwh">
-      ...
-    </div>
+<div class="example-contentful-module example-content-model-text" data-msqc-entry-id="{{$entryId}}" data-msqc-space-id="{{$entryId}}">
+  <div class="{{$example2}} size"@if(isset($example)) id="{{$example}}"@endif>
+    {!! $example3 !!}
   </div>
 </div>
 ```

--- a/src/chrome/manifest.json
+++ b/src/chrome/manifest.json
@@ -1,9 +1,9 @@
 {
     "manifest_version": 2,
-    "name": "Contentful Sidekick",
-    "short_name": "Contentful Sidekick",
-    "description": "Chrome Extension that enables inline editing for websites created in Contentful",
-    "version": "0.0.6",
+    "name": "MSQC Contentful Sidekick",
+    "short_name": "MSQC Contentful Sidekick",
+    "description": "Chrome Extension that enables inline editing for MSQC websites created in Contentful",
+    "version": "0.0.1",
     "permissions": [
       "activeTab",
       "cookies",
@@ -20,7 +20,7 @@
     },
     "content_scripts": [
       {
-        "matches": ["http://*/*", "https://*/*"], 
+        "matches": ["http://*/*", "https://*/*"],
         "js": ["js/vendor.js", "js/content.js"],
         "css": ["css/content.css"]
       }
@@ -30,4 +30,3 @@
     ],
     "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'"
   }
-  

--- a/src/shared/css/content.css
+++ b/src/shared/css/content.css
@@ -1,13 +1,13 @@
-.csk-element {
+.msqc-element {
   outline: 1px dashed #00a7f7;
   cursor: pointer;
 }
-.csk-element:hover {
+.msqc-element:hover {
   outline: 1px solid #00a7f7;
   box-shadow: 0 0 0 4px rgba(0, 167, 247, 0.3);
 }
 
-.csk-element:hover:before {
+.msqc-element:hover:before {
   content: 'EDIT';
   position: absolute;
   padding: 2px 5px;

--- a/src/shared/css/popup.css
+++ b/src/shared/css/popup.css
@@ -1,4 +1,4 @@
-/* Sidekick popup styles */
+/*MSQC Sidekick popup styles */
 body {
     margin: 0;
 }

--- a/src/shared/html/popup.html
+++ b/src/shared/html/popup.html
@@ -3,25 +3,25 @@
 <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Contentful Sidekick</title>
+    <title>MSQC Contentful Sidekick</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" media="screen" href="/css/popup.css" />
 </head>
 <body>
     <header>
         <div>
-            <h1>Contentful Sidekick</h1>
+            <h1>MSQC Contentful Sidekick</h1>
         </div>
     </header>
     <main>
         <div class="enable">
-            <span>Enable Sidekick</span>
+            <span>Enable MSQC Sidekick</span>
             <input type="checkbox" id="sideKickEnabled" />
             <label for="sideKickEnabled"></label>
         </div>
     </main>
     <footer>
-        <span class="version">v0.0.6</span>
+        <span class="version">v0.0.1</span>
     </footer>
     <script type="text/javascript" src="/js/vendor.js"></script>
     <script type="text/javascript" src="/js/popup.js"></script>

--- a/src/shared/js/content.js
+++ b/src/shared/js/content.js
@@ -10,27 +10,31 @@ $(() => {
 
   getState.then((active) => {
     if (active) {
-      const CONTENTFUL_CURRENT_SPACE_ID = $('[name="contentful_space"]').attr('content');
-      const CONTENTFUL_ENVIRONMENT = $('[name="contentful_environment"]').attr('content');
-
-      const getContentfulUrl = (elementId) => {
-        return `https://app.contentful.com/spaces/${CONTENTFUL_CURRENT_SPACE_ID}/environments/${CONTENTFUL_ENVIRONMENT}/entries/${elementId}`;
+      const getContentfulUrl = (elementId, spaceId) => {
+        return `https://app.contentful.com/spaces/${spaceId}/entries/${elementId}`;
       };
 
-      if (CONTENTFUL_CURRENT_SPACE_ID && CONTENTFUL_ENVIRONMENT) {
-        $.each($('[data-csk-entry-id]'), (index, el) => {
-          // Get the data for each element
-          const elementId = $(el).data('csk-entry-id');
-          $(el)
-            .addClass('csk-element')
-            .off('click')
-            .on('click', (e) => {
-              if ($(e.target).data('csk-entry-id') !== elementId) return;
-              e.stopPropagation();
-              window.open(getContentfulUrl(elementId));
-            });
-        });
-      }
+
+      $.each($('[data-msqc-entry-id]'), (index, el) => {
+        // Get the data for each element
+        const elementId = $(el)
+          .data('msqc-entry-id');
+        const spaceId = $(el)
+          .data('msqc-space-id');
+        $(el)
+          .addClass('msqc-element')
+          .off('click')
+          .on('click', (e) => {
+            if ($(e.target)
+              .data('msqc-entry-id') !== elementId && $(e.target)
+              .data('msqc-space-id') !== spaceId) {
+              return;
+            }
+            e.stopPropagation();
+            window.open(getContentfulUrl(elementId, spaceId));
+          });
+      });
     }
+
   });
 });


### PR DESCRIPTION
…es in CSS and replaced references in .js files.

modified README.md to list changes made to extension and why.
Reworked content.js to accept Space ID as an additional paramater so when we have pages with mixed spaces
 (think global header on landing page or homepage) we still get correct links per entry